### PR TITLE
ActiveSupport 3.0 support and Bundler-based dependency management

### DIFF
--- a/bcdatabase.gemspec
+++ b/bcdatabase.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.executables = ['bcdatabase']
   s.files = Dir.glob("{CHANGELOG.markdown,LICENSE,README.markdown,{bin,lib}/**/*}")
 
-  s.add_dependency "activesupport", "~> 2.0"
+  s.add_dependency "activesupport", ">= 2.0"
   s.add_dependency "highline", "~> 1.6"
 
   s.add_development_dependency 'rspec', "~> 1.2"

--- a/spec/bcdatabase_spec.rb
+++ b/spec/bcdatabase_spec.rb
@@ -225,8 +225,7 @@ describe Bcdatabase do
       end
 
       it "has a single top-level key" do
-        @actual.keys.should have(1).key
-        @actual.should have_key("development")
+        @actual.keys.should == ["development"]
       end
 
       it "reflects the selected configuration" do


### PR DESCRIPTION
Hi Rhett,

This pull request relaxes bcdatabase's dependency specifications to permit ActiveSupport 3.x.  Although one example was changed to eliminate a dependency on ActiveSupport's inflector, no changes to bcdatabase library code were necessary to get bcdatabase specs passing with ActiveSupport 3.0.3.

This pull request also contains a restructuring of bcdatabase's gem structure that eliminates Jeweler and uses Bundler for dependency management.

(The gem restructuring is available separately in the `simplify-gem-structure` head, if you prefer to apply it separately from the ActiveSupport 3 changes.)
