### PR TITLE
fix long epasswords

### DIFF
--- a/lib/bcdatabase.rb
+++ b/lib/bcdatabase.rb
@@ -51,7 +51,7 @@ module Bcdatabase
     ##
     # @private exposed for collaboration
     def encrypt(s)
-      Base64.encode64(encipher(:encrypt, s)).strip
+      Base64.strict_encode64(encipher(:encrypt, s)).strip
     end
 
     ##

--- a/spec/bcdatabase_spec.rb
+++ b/spec/bcdatabase_spec.rb
@@ -23,6 +23,10 @@ describe Bcdatabase do
       ENV["BCDATABASE_PASS"] = nil
     end
 
+    it "should not have newlines in long encrypted passwords" do
+      Bcdatabase.encrypt("CKvWShwhUAIXAbBBKHfRDZzaXV1oOIzTfnZ8NGuCB7f9vGO0bFVUIgEtJbm5").match('\n').should be_nil
+    end
+
     it "should be reversible" do
       e = Bcdatabase.encrypt("riboflavin")
       Bcdatabase.decrypt(e).should == "riboflavin"


### PR DESCRIPTION
Hi Rhett, 

Hope this is okay for you.

Fixed new lines occurring in epassword when password length is > 45 characters.
