### PR TITLE
thor gem no longer locked down

### DIFF
--- a/bcdatabase.gemspec
+++ b/bcdatabase.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency "activesupport", ">= 2.0"
   s.add_dependency "highline", "~> 1.5", '< 1.6.9'
   s.add_dependency "i18n"
-  s.add_dependency 'thor', '~> 0.14.6'
+  s.add_dependency 'thor', '>= 0.14.6'
 
   s.add_development_dependency 'bundler', '~> 1.0', '>= 1.0.15'
   s.add_development_dependency 'rake', '~> 0.9.2'


### PR DESCRIPTION
This eases the dependencies for thor by allowing higher versions. 

Tests pass for ruby 1.9.3p125.

Was there a particular reason why this was locked down? I don't want to introduce a regression that I am not aware of.

Thanks
Phil
