### PR TITLE
Relax highline dependency

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -3,7 +3,7 @@ Bcdatabase history
 
 1.2.5
 -----
-- Loosen highline dependency, as the [issue](https://github.com/NUBIC/bcdatabase/issues/17) has been [resolved](https://github.com/JEG2/highline/pull/67). (#22)
+- Loosen highline dependency, as the [issue](https://github.com/NUBIC/bcdatabase/issues/17) has been [resolved](https://github.com/JEG2/highline/pull/67). (#23)
 
 1.2.4
 -----

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -3,6 +3,7 @@ Bcdatabase history
 
 1.2.5
 -----
+- Loosen highline dependency, as the [issue](https://github.com/NUBIC/bcdatabase/issues/17) has been [resolved](https://github.com/JEG2/highline/pull/67). (#22)
 
 1.2.4
 -----

--- a/bcdatabase.gemspec
+++ b/bcdatabase.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.executables = ['bcdatabase']
   s.files = Dir.glob("{CHANGELOG.markdown,LICENSE,README.markdown,bcdatabase.gemspec,{bin,lib}/**/*}")
 
-  s.add_dependency "highline", "~> 1.5", '< 1.6.9'
+  s.add_dependency 'highline', '~> 1.5'
   s.add_dependency 'thor', '~> 0.14'
 
   s.add_development_dependency 'bundler', '~> 1.0', '>= 1.0.15'


### PR DESCRIPTION
Loosen highline dependency, as the [issue](https://github.com/NUBIC/bcdatabase/issues/17) has been [resolved](https://github.com/JEG2/highline/pull/67).
